### PR TITLE
Minor: Add [[examples]] to the Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,12 @@ keywords = ["gcode", "no_std", "MEX", "FDM", "3d_printing"]
 
 [dependencies]
 clap = { version = "4.5.26", features = ["derive"] }
+
+[[example]]
+name = "pack"
+
+[[example]]
+name = "unpack"
+
+[[example]]
+name = "pack_unpack"


### PR DESCRIPTION
I love this project .. it really nicely laid out. 

This is just a minor nudge


The existing code conforms to the pattern :-

<https://doc.rust-lang.org/cargo/reference/cargo-targets.html#examples>

This PR - allows command such as :-

```sh
cargo run --example pack_unpack
```

